### PR TITLE
Optimize shared audio performance

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -11,11 +11,17 @@ module.exports = {
     }],
     ['module-resolver', {
       root: ['./src'],
-      extensions: ['.ios.js', '.android.js', '.js', '.ts', '.tsx', '.json'],
+      extensions: ['.ios.js', '.android.js', '.native.js', '.js', '.native.ts', '.native.tsx', '.ts', '.tsx', '.json'],
       alias: {
         '@': './src',
       }
     }],
     'react-native-worklets/plugin',
+    // Inline react-native-paper icons to reduce dynamic requires
+    'react-native-paper/babel',
+    // Dead code elimination hints
+    ['transform-inline-environment-variables', {
+      include: ['NODE_ENV']
+    }],
   ]
 };

--- a/metro.config.js
+++ b/metro.config.js
@@ -6,6 +6,15 @@ const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
  *
  * @type {import('@react-native/metro-config').MetroConfig}
  */
-const config = {};
+const config = {
+	transformer: {
+		getTransformOptions: async () => ({
+			transform: {
+				experimentalImportSupport: false,
+				inlineRequires: true,
+			},
+		}),
+	},
+};
 
 module.exports = mergeConfig(getDefaultConfig(__dirname), config);

--- a/package.json
+++ b/package.json
@@ -19,7 +19,11 @@
     "start": "react-native start",
     "test": "jest",
     "test:auth": "jest __tests__/auth --passWithNoTests",
-    "prepare": "husky"
+    "prepare": "husky",
+    "bundle:android": "react-native bundle --platform android --dev false --entry-file index.js --bundle-output ./build/index.android.bundle --assets-dest ./build | cat",
+    "bundle:ios": "react-native bundle --platform ios --dev false --entry-file index.js --bundle-output ./build/index.ios.bundle --assets-dest ./build | cat",
+    "analyze:android": "npm run bundle:android && npx react-native bundle-visualizer ./build/index.android.bundle --open false | cat",
+    "analyze:ios": "npm run bundle:ios && npx react-native bundle-visualizer ./build/index.ios.bundle --open false | cat"
   },
   "dependencies": {
     "@bam.tech/react-native-image-resizer": "^3.0.11",
@@ -111,7 +115,8 @@
     "prettier": "2.8.8",
     "react-test-renderer": "19.1.0",
     "resolve.exports": "^2.0.3",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "react-native-bundle-visualizer": "^5.1.1"
   },
   "engines": {
     "codegenConfig": {

--- a/shared/Audio/noise/NoiseReducer.cpp
+++ b/shared/Audio/noise/NoiseReducer.cpp
@@ -137,14 +137,12 @@ void NoiseReducer::processStereo(const float* inL, const float* inR, float* outL
 }
 
 void NoiseReducer::processChannel(const float* in, float* out, size_t n, ChannelState& st) {
-    // Optional high-pass pre-filter to remove rumble
+    // Optional high-pass pre-filter to remove rumble (avoid per-call allocations)
     if (st.highPass) {
-        std::vector<float> inputVec(in, in + n);
-        std::vector<float> outputVec(n);
-        st.highPass->process(inputVec, outputVec);
-        // Copy filtered data back
-        std::copy(outputVec.begin(), outputVec.end(), out);
-        in = out; // For in-place operation, update input pointer
+        // Process directly using pointer-based API to avoid vector allocations
+        st.highPass->process(in, out, n);
+        // For in-place operation, update input pointer to filtered output
+        in = out;
     } else if (out != in) {
         // Only copy if buffers are different
         std::copy_n(in, n, out);

--- a/specs/NativeAudioEqualizerModule.ts
+++ b/specs/NativeAudioEqualizerModule.ts
@@ -124,4 +124,19 @@ export interface Spec extends TurboModule {
   ) => void;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('NativeAudioEqualizerModule');
+let _nativeAudioModule: Spec | null = null;
+const getNativeAudioModule = (): Spec => {
+  if (!_nativeAudioModule) {
+    _nativeAudioModule = TurboModuleRegistry.getEnforcing<Spec>('NativeAudioEqualizerModule');
+  }
+  return _nativeAudioModule;
+};
+
+const LazyNativeAudioEqualizerModule: Spec = new Proxy({} as any, {
+  get: (_target, prop) => {
+    const mod = getNativeAudioModule() as any;
+    return mod[prop as keyof Spec];
+  },
+}) as Spec;
+
+export default LazyNativeAudioEqualizerModule;

--- a/specs/NativeCameraFiltersModule.ts
+++ b/specs/NativeCameraFiltersModule.ts
@@ -197,6 +197,21 @@ export interface Spec extends TurboModule {
   readonly setCacheSize: (sizeInMB: number) => boolean;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('NativeCameraFiltersModule');
+let _nativeCameraModule: Spec | null = null;
+const getNativeCameraModule = (): Spec => {
+  if (!_nativeCameraModule) {
+    _nativeCameraModule = TurboModuleRegistry.getEnforcing<Spec>('NativeCameraFiltersModule');
+  }
+  return _nativeCameraModule;
+};
+
+const LazyNativeCameraFiltersModule: Spec = new Proxy({} as any, {
+  get: (_target, prop) => {
+    const mod = getNativeCameraModule() as any;
+    return mod[prop as keyof Spec];
+  },
+}) as Spec;
+
+export default LazyNativeCameraFiltersModule;
 
 

--- a/src/hooks/useAudioWorker.native.ts
+++ b/src/hooks/useAudioWorker.native.ts
@@ -1,0 +1,20 @@
+/**
+ * React Native (iOS/Android) stub for audio worker to avoid bundling web worker code.
+ */
+
+import { useMemo } from 'react';
+
+export const useAudioWorker = () => {
+	const api = useMemo(() => {
+		return {
+			isReady: false,
+			error: new Error('Web Workers are not supported on React Native'),
+			processSpectrum: async (audioData: Float32Array | Float64Array) => audioData,
+			calculateRMS: async (_audioData: Float32Array, _windowSize: number = 1024) => new Float32Array(0),
+			applyFilter: async (audioData: Float32Array) => audioData,
+			processBatch: async (operations: any[]) => operations,
+		};
+	}, []);
+
+	return api;
+};


### PR DESCRIPTION
Optimize bundle size, load times, and `shared/Audio` performance.

This PR introduces several performance enhancements: lazy-loading of native modules and enabling Metro's `inlineRequires` to reduce initial bundle evaluation, a React Native-specific stub for `useAudioWorker` to prevent web worker code from being bundled on native platforms, and an optimization in `NoiseReducer::processChannel` to eliminate per-call `std::vector` allocations in a C++ audio processing hot path.

---
<a href="https://cursor.com/background-agent?bcId=bc-db83a638-9b22-4151-9545-f4c86790613a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-db83a638-9b22-4151-9545-f4c86790613a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

