### PR TITLE
Check shared audio directory for missing includes

### DIFF
--- a/shared/Audio/core/AudioEqualizer.h
+++ b/shared/Audio/core/AudioEqualizer.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "AudioEqualizer.hpp"

--- a/shared/Audio/core/BiquadFilter.h
+++ b/shared/Audio/core/BiquadFilter.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "BiquadFilter.hpp"

--- a/shared/Audio/utils/Constants.hpp
+++ b/shared/Audio/utils/Constants.hpp
@@ -1,0 +1,4 @@
+#pragma once
+
+// Compatibility header: forward to the canonical utilsConstants.hpp
+#include "utilsConstants.hpp"


### PR DESCRIPTION
Add compatibility headers to `shared/Audio` to resolve missing includes.

These shim headers (`shared/Audio/utils/Constants.hpp`, `shared/Audio/core/AudioEqualizer.h`, `shared/Audio/core/BiquadFilter.h`) forward to their canonical `.hpp` counterparts, addressing the reported missing includes and allowing the verification script to pass.

---
<a href="https://cursor.com/background-agent?bcId=bc-905661a7-33b2-4093-abbc-0d186f3bd471">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-905661a7-33b2-4093-abbc-0d186f3bd471">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

