### PR TITLE
Code review for audio noise module

### DIFF
--- a/ios/Nyth/NativeModuleProvider.mm
+++ b/ios/Nyth/NativeModuleProvider.mm
@@ -19,7 +19,7 @@
 #include "../../shared/Audio/safety/NativeAudioSafetyModule.h"
 #include "../../shared/Audio/fft/NativeAudioSpectrumModule.h"
 #include "../../shared/Audio/utils/NativeAudioUtilsModule.h"
-v
+#include <memory>
 #include <memory>
 
 #endif

--- a/shared/Audio/noise/NativeAudioNoiseModule.cpp
+++ b/shared/Audio/noise/NativeAudioNoiseModule.cpp
@@ -15,10 +15,6 @@ using Nyth::Audio::NoiseState;
 
 NativeAudioNoiseModule::NativeAudioNoiseModule(std::shared_ptr<CallInvoker> jsInvoker)
     : TurboModule("NativeAudioNoiseModule", jsInvoker), jsInvoker_(std::move(jsInvoker)) {
-
-NativeAudioNoiseModule::NativeAudioNoiseModule(std::shared_ptr<CallInvoker> jsInvoker) : TurboModule() {
-    jsInvoker_ = jsInvoker;
-
     // Initialisation des composants
     initializeManagers();
 
@@ -832,7 +828,7 @@ void NativeAudioNoiseModule::onProcessingComplete(const float* input, const floa
     if (callbackManager_ && runtimeValid_.load()) {
         try {
             // Transmet les buffers d'entrée et de sortie via Float32Array
-            callbackManager_->invokeAudioIOCallback(input, output, frameCount, 1);
+            callbackManager_->invokeAudioIOCallback(input, output, frameCount, config_.channels);
         } catch (const std::exception& e) {
             // Silencer les erreurs de callback
         }

--- a/shared/Audio/noise/NativeAudioNoiseModule.h
+++ b/shared/Audio/noise/NativeAudioNoiseModule.h
@@ -27,6 +27,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <mutex>
 
 #include <ReactCommon/TurboModule.h>
 #include <ReactCommon/TurboModuleUtils.h>


### PR DESCRIPTION
Fix compilation issues and align JSI callback usage and audio channel reporting in the Noise module for improved correctness.

The previous implementation had a duplicate constructor, a missing `<mutex>` include, and a stray character causing compilation failures. Additionally, the `NoiseManager` was using non-existent `notifyStatistics` and `notifyError` methods, which have been replaced with the correct `invokeCallback` and `invokeErrorCallback` from the common JSI callback manager. The audio processing callback now correctly reports the number of channels.

---
<a href="https://cursor.com/background-agent?bcId=bc-1e924b30-ad24-4032-802b-369272f8b120">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1e924b30-ad24-4032-802b-369272f8b120">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

